### PR TITLE
Update tenant.json

### DIFF
--- a/config/tenant.json
+++ b/config/tenant.json
@@ -47,7 +47,6 @@
         "apiSpecFileNames": [
           "account-1.8.0",
           "card-2.10.0",
-          "card-2.8.0",
           "dispute-1.6.3",
           "fraud-1.8.0"
           ]


### PR DESCRIPTION
June release is:
2.13 is in current
2.10 is in previous

(removed 2.8.0)