### PR TITLE
Update new-fraud-sandbox.md

### DIFF
--- a/docs/release-notes/fraud/new-fraud-sandbox.md
+++ b/docs/release-notes/fraud/new-fraud-sandbox.md
@@ -2005,6 +2005,7 @@ Provides information to identify the given cardholder on the third party vendorâ
 
 **Target URL:** /client/provided/uri
 
+
 ``` 
 {
    "schemaVersion": "1.0.0",


### PR DESCRIPTION
still open question for Farud Alert target URL 
 - bad line at 2006 is **Target URL:** /client/provided/uri