### PR TITLE
Create get-started.md

### DIFF
--- a/config/tenant.json
+++ b/config/tenant.json
@@ -17,7 +17,7 @@
       ]
     }
   ],
-  "getStartedFilePath": "/docs/gettingstarted/getting-started.md",
+  "getStartedFilePath": "docs/get-started.md",
   "apiVersions": [ 
       {
         "version": "api",

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,0 +1,58 @@
+# Overview
+This document is an introduction and quick access, how-to guide when learning to use the Fiserv Developer Studio©: Card Developer©. Companies can use the Fiserv Card Developer API solutions for company-branded digital applications to embed services and capabilities for their customers. You can create, update, and control the financial services provided by Fiserv APIs for your clients under your company branding.
+
+
+* [New client information](?path=/docs/gettingstarted/getting-started-when-new.md)
+* [Existing client information](?path=/docs/gettingstarted/getting-started-when-migerating.md)
+
+
+## Developer Studio Highlights
+Card Developer includes the following features:
+*	Create Account—Used to create an account, in the Card Developer Workspace. Located in the top menu area prior to signing into Studio Developer.
+*	API explorer—An interactive research tools for technical information, key management, and credentials. Located in the lower half of the left-side panel.
+*	Create Workspace—Clients create Card Developer Workspace(s). The Card Developer Workspace contains the API keys/Credentials of the Client's company. You can create more workspace types for other purposes.
+*	Add API Keys—Clients add API keys to the workspace. The API key and Secret are used to obtain an access token. You must register with Fiserv as a client before you can create API keys for Production environment. Then you must get the API keys approved for Fiserv Production environment. See also, New clients.
+  
+*Note: We used to refer to the previous API Card Developer portal simply as “app”.*
+
+The following graphics show you a visual representation the highlights outlined above. 
+
+![](assets/images/getStarted/CardDev-top.png)
+
+![](assets/images/getStarted/Add-an-API-key-button.png)
+
+In the Card Developer Workspace, Clients can establish two roles with differing capabilities. The two 
+roles are as follows:
+**Company Administrator**—The Card Developer Workspace creator is the default Company 
+Administrator. The Company Administrator is the designated organization representative with all 
+administrative privileges:
+
+* Manage the Card Developer Workspace.
+* Invite Company Developers.
+* Designate secondary Company Administrators. 
+* Delete a Card Developer Workspace.
+
+**Company Developer**—This role type is a subset of the Company Administrators account type with the 
+following privileges:
+
+* Can view and use Sandbox API Keys created by Company Administrator
+* Get access to the Company Production API Keys created by the Company Administrator.
+* Can test API Keys in the Sandbox environment.
+* View/read privileges to the Company API products and features.
+
+### Limitations
+* The Card Developer Workspace is not a server endpoint and API keys cannot be staged or tested 
+directly on the Card Developer Workspace. 
+* Developers must use an independent method, such as Curl or Postman, pointed at the Sandbox 
+endpoints to test API keys.
+
+### Sandbox environment
+The sandbox environment is a safe testing ground that isolates code for developers. Clients can mimic 
+the production environment and create simulated responses. The simulated responses are based on test 
+cases and data. The sandbox environment is identical to production but points to a simulated API 
+environment for API responses.
+
+For details, more specific to your Card Developer needs, select one of the following:
+
+* [New client information](?path=/docs/gettingstarted/getting-started-when-new.md)
+* [Existing client information](?path=/docs/gettingstarted/getting-started-when-migerating.md)


### PR DESCRIPTION
copied getting-started.md due to standardizing the "get started" path and filename.
 This is the md file that is linked to the "rocket ship" Get Started. It is specified in tenant.json (getStartedFilePath).